### PR TITLE
Added tcp keepalive settings to socket

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
 # Change Log
+## 0.1.1
+- Added TCP Keepalive options to the socket connection
 ## 0.1.0
 - First release

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - napalm
   - syslog
   - networking
-version: 0.1.0
+version: 0.1.1
 author: John Anderson
 email: lampwins@gmail.com

--- a/sensors/napalm_logs_client.py
+++ b/sensors/napalm_logs_client.py
@@ -22,6 +22,15 @@ class NapalmLogsSensor(Sensor):
         context = zmq.Context()
         # pylint: disable=no-member
         self.socket = context.socket(zmq.SUB)
+
+        # override OS tcp keepalive settings to keep socket open
+        # pylint: disable=no-member
+        self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
+        # pylint: disable=no-member
+        self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 300)
+        # pylint: disable=no-member
+        self.socket.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 300)
+
         self.socket.connect('tcp://{address}:{port}'.format(address=self._server_address,
                                                             port=self._server_port))
         # pylint: disable=no-member


### PR DESCRIPTION
Testing on Ubuntu boxes shows that OS level TCP keepalive settings need to be overridden on the socket connection.