### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 # Change Log
+
+## 1.0.1
+
+* Added dummy action so that the ST2 CI pipeline does not fail when registering actions
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/actions/dummyaction
+++ b/actions/dummyaction
@@ -1,0 +1,1 @@
+# Only here so that the ST2 CI pipeline does not fail when running Register Action tests

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - napalm
   - syslog
   - networking
-version: 1.0.0
+version: 1.0.1
 author: John Anderson
 email: lampwins@gmail.com
 python_versions:


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- Added dummy action so that the ST2 CI pipeline does not fail when registering actions